### PR TITLE
had initial condition for assignees wrong, ceFlutter would not be abl…

### DIFF
--- a/webServer/tests/testBasicFlow.js
+++ b/webServer/tests/testBasicFlow.js
@@ -339,7 +339,7 @@ async function testBlast( authData, ghLinks, td ) {
     let links  = await tu.getLinks( authData, ghLinks, { "repo": td.GHFullName } );
     let link   = links.find( link => link.GHIssueTitle == "Blast 1" );
     let card   = await tu.getCard( authData, link.GHCardId );
-    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 1});
+    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 1, assigns: [ASSIGNEE1]});
 
     tu.testReport( testStatus, "Test Blast A" );    
 
@@ -349,7 +349,7 @@ async function testBlast( authData, ghLinks, td ) {
     links  = await tu.getLinks( authData, ghLinks, { "repo": td.GHFullName } );
     link   = links.find( link => link.GHIssueTitle == "Blast 2" );
     card   = await tu.getCard( authData, link.GHCardId );
-    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 3});
+    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 3, assigns: [ASSIGNEE1, ASSIGNEE2]});
 
     tu.testReport( testStatus, "Test Blast B" );    
 
@@ -359,7 +359,7 @@ async function testBlast( authData, ghLinks, td ) {
     links  = await tu.getLinks( authData, ghLinks, { "repo": td.GHFullName } );
     link   = links.find( link => link.GHIssueTitle == "Blast 3" );
     card   = await tu.getCard( authData, link.GHCardId );
-    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 2});
+    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 2, assigns: [ASSIGNEE1, ASSIGNEE2]});
 
     tu.testReport( testStatus, "Test Blast C" );    
 
@@ -369,7 +369,7 @@ async function testBlast( authData, ghLinks, td ) {
     links  = await tu.getLinks( authData, ghLinks, { "repo": td.GHFullName } );
     link   = links.find( link => link.GHIssueTitle == "Blast 4" );
     card   = await tu.getCard( authData, link.GHCardId );
-    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 2});
+    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 2, assigns: [ASSIGNEE1, ASSIGNEE2]});
 
     tu.testReport( testStatus, "Test Blast D" );    
 
@@ -379,7 +379,7 @@ async function testBlast( authData, ghLinks, td ) {
     links  = await tu.getLinks( authData, ghLinks, { "repo": td.GHFullName } );
     link   = links.find( link => link.GHIssueTitle == "Blast 5" );
     card   = await tu.getCard( authData, link.GHCardId );
-    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 3});
+    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 3, assigns: [ASSIGNEE2, ASSIGNEE1]});
 
     tu.testReport( testStatus, "Test Blast E" );    
 
@@ -394,7 +394,8 @@ async function testBlast( authData, ghLinks, td ) {
     links  = await tu.getLinks( authData, ghLinks, { "repo": td.GHFullName } );
     link   = links.find( link => link.GHIssueTitle == "Blast 6" );
     card   = await tu.getCard( authData, link.GHCardId );
-    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 1});
+    // Assigns show up still - peq assignees not updated once created until ceFlutter
+    testStatus = await tu.checkUnclaimedIssue( authData, ghLinks, td, uncLoc, issDat, card, testStatus, {label: 604, lblCount: 1, assigns: [ASSIGNEE1, ASSIGNEE2]});
 
     tu.testReport( testStatus, "Test Blast F" );    
 

--- a/webServer/tests/testComponents.js
+++ b/webServer/tests/testComponents.js
@@ -308,14 +308,15 @@ async function testLabel( authData, ghLinks, td ) {
 	// 5. relabel (OK here, negotiating)
 	await tu.addLabel( authData, td, issueData[1], label500.name );    
 	await utils.sleep( 1000 );
-	testStatus = await tu.checkSituatedIssue( authData, ghLinks, td, flatPend, issueData, card, testStatus, {"label": 500 } );
+	// re-created peq, i.e. re-peq-labeled.  Gets assignees again.
+	testStatus = await tu.checkSituatedIssue( authData, ghLinks, td, flatPend, issueData, card, testStatus, {label: 500, assign: 1 } );
 	await utils.sleep( 1000 );
 	tu.testReport( testStatus, "Label flat 6" );
 	
 	// 6. move to accr
 	await tu.moveCard( authData, card.id, flatAccr.colId );
 	await utils.sleep( 1000 );
-	testStatus = await tu.checkSituatedIssue( authData, ghLinks, td, flatAccr, issueData, card, testStatus, {"label": 500 } );
+	testStatus = await tu.checkSituatedIssue( authData, ghLinks, td, flatAccr, issueData, card, testStatus, {label: 500, assign: 1 } );
 	tu.testReport( testStatus, "Label flat 7" );
     }
 
@@ -1287,12 +1288,12 @@ async function runTests( authData, ghLinks, td ) {
 
     let testStatus = [ 0, 0, []];
 
-    let t8 = await testAlloc( authData, ghLinks, td );
-    console.log( "\n\nAlloc complete." );
-    await utils.sleep( 5000 );
-
     let t1 = await testAssignment( authData, ghLinks, td );
     console.log( "\n\nAssignment test complete." );
+    await utils.sleep( 5000 );
+
+    let t8 = await testAlloc( authData, ghLinks, td );
+    console.log( "\n\nAlloc complete." );
     await utils.sleep( 5000 );
     
     let t2 = await testLabel( authData, ghLinks, td ); 

--- a/webServer/tests/testCross.js
+++ b/webServer/tests/testCross.js
@@ -57,7 +57,7 @@ async function testCrossRepo( authData, authDataX, ghLinks, td, tdX ) {
     const card  = await tu.makeProjectCard( authData, stripeLoc.colId, issDat[0] );
     await utils.sleep( 1000 );
     
-    testStatus = await tu.checkSituatedIssue( authData, ghLinks, td, stripeLoc, issDat, card, testStatus, {label: 704, lblCount: 1});
+    testStatus = await tu.checkSituatedIssue( authData, ghLinks, td, stripeLoc, issDat, card, testStatus, {label: 704, lblCount: 1, assign: 2});
     
     let allPeqs = await utils.getPeqs( authData, { "GHRepo": td.GHFullName });
     let peq     = allPeqs.find(p => p.GHIssueId == issDat[0].toString() );
@@ -74,7 +74,7 @@ async function testCrossRepo( authData, authDataX, ghLinks, td, tdX ) {
     const cardX  = await tu.makeProjectCard( authDataX, crossLoc.colId, issDatX[0] );
     await utils.sleep( 1000 );
     
-    testStatus = await tu.checkSituatedIssue( authDataX, ghLinks, tdX, crossLoc, issDatX, cardX, testStatus, {label: 704, lblCount: 1});
+    testStatus = await tu.checkSituatedIssue( authDataX, ghLinks, tdX, crossLoc, issDatX, cardX, testStatus, {label: 704, lblCount: 1, assign: 2});
     
     allPeqs  = await utils.getPeqs( authDataX, { "GHRepo": tdX.GHFullName });
     let peqX = allPeqs.find(p => p.GHIssueId == issDatX[0].toString() );

--- a/webServer/tests/testUtils.js
+++ b/webServer/tests/testUtils.js
@@ -839,11 +839,13 @@ async function checkSituatedIssue( authData, ghLinks, td, loc, issueData, card, 
     testStatus  = checkEq( peqs.length, 1,                          testStatus, "Peq count" );
     let peq = peqs[0];
 
+    assignCnt = assignCnt ? assignCnt : 0;
+    
     testStatus = checkEq( peq.PeqType, loc.peqType,                testStatus, "peq type invalid" );        
     testStatus = checkEq( peq.GHProjectSub.length, loc.projSub.length, testStatus, "peq project sub len invalid" );
     testStatus = checkEq( peq.GHIssueTitle, issueData[2],          testStatus, "peq title is wrong" );
-    testStatus = checkEq( peq.GHHolderId.length, 0,                testStatus, "peq holders wrong" );      
-    testStatus = checkEq( peq.CEHolderId.length, 0,                testStatus, "peq holders wrong" );    
+    testStatus = checkEq( peq.GHHolderId.length, assignCnt,        testStatus, "peq holders wrong" );      
+    testStatus = checkEq( peq.CEHolderId.length, 0,                testStatus, "peq ceholders wrong" );    
     testStatus = checkEq( peq.CEGrantorId, config.EMPTY,           testStatus, "peq grantor wrong" );      
     testStatus = checkEq( peq.Amount, lval,                        testStatus, "peq amount" );
     testStatus = checkEq( peq.GHProjectSub[0], loc.projSub[0],     testStatus, "peq project sub 0 invalid" );
@@ -883,6 +885,7 @@ async function checkUnclaimedIssue( authData, ghLinks, td, loc, issueData, card,
 
     let labelVal     = typeof specials !== 'undefined' && specials.hasOwnProperty( "label" )        ? specials.label        : false;
     let labelCnt     = typeof specials !== 'undefined' && specials.hasOwnProperty( "lblCount" )     ? specials.lblCount     : 1;
+    let assignees    = typeof specials !== 'undefined' && specials.hasOwnProperty( "assigns" )      ? specials.assigns      : [];
     
     console.log( "Check unclaimed issue", loc.projName, loc.colName, labelVal );
 
@@ -929,14 +932,18 @@ async function checkUnclaimedIssue( authData, ghLinks, td, loc, issueData, card,
     testStatus = checkEq( peq.PeqType, loc.peqType,                testStatus, "peq type invalid" );        
     testStatus = checkEq( peq.GHProjectSub.length, loc.projSub.length, testStatus, "peq project sub len invalid" );
     testStatus = checkEq( peq.GHIssueTitle, issueData[2],          testStatus, "peq title is wrong" );
-    testStatus = checkEq( peq.GHHolderId.length, 0,                testStatus, "peq holders wrong" );      
-    testStatus = checkEq( peq.CEHolderId.length, 0,                testStatus, "peq holders wrong" );    
+    testStatus = checkEq( peq.GHHolderId.length, assignees.length, testStatus, "peq holders wrong" );      
+    testStatus = checkEq( peq.CEHolderId.length, 0,                testStatus, "peq ce holders wrong" );    
     testStatus = checkEq( peq.CEGrantorId, config.EMPTY,           testStatus, "peq grantor wrong" );      
     testStatus = checkEq( peq.Amount, lval,                        testStatus, "peq amount" );
     testStatus = checkEq( peq.GHProjectSub[0], loc.projSub[0],     testStatus, "peq project sub 0 invalid" );
     testStatus = checkEq( peq.Active, "true",                      testStatus, "peq" );
     testStatus = checkEq( peq.GHProjectId, loc.projId,             testStatus, "peq project id bad" );
 
+    for( const assignee of assignees ) {
+	testStatus = checkEq( peq.GHHolderId.includes( assignee ), true, testStatus, "peq holder bad" );
+    }
+    
     // CHECK dynamo Pact
     let allPacts  = await pactsP;
     let pacts = allPacts.filter((pact) => pact.Subject[0] == peq.PEQId );
@@ -1464,7 +1471,7 @@ async function checkAssignees( authData, td, assigns, issueData, testStatus ) {
     testStatus = checkEq( meltPeq.GHProjectSub.length, 2,              testStatus, "peq project sub invalid" );
     testStatus = checkEq( meltPeq.GHIssueTitle, issueData[2],          testStatus, "peq title is wrong" );
     testStatus = checkEq( meltPeq.GHHolderId.length, 0,                testStatus, "peq holders wrong" );
-    testStatus = checkEq( meltPeq.CEHolderId.length, 0,                testStatus, "peq holders wrong" );
+    testStatus = checkEq( meltPeq.CEHolderId.length, 0,                testStatus, "peq ceholders wrong" );
     testStatus = checkEq( meltPeq.CEGrantorId, config.EMPTY,           testStatus, "peq grantor wrong" );
     testStatus = checkEq( meltPeq.Amount, 1000,                        testStatus, "peq amount" );
     testStatus = checkEq( meltPeq.GHProjectSub[0], td.softContTitle,   testStatus, "peq project sub invalid" );


### PR DESCRIPTION
…e to reconstruct.  Now add assignees when peq is first created, then

 rely on PAct to keep up to date.  When transfering from unclaimed, copy.  When re-labeling, get from GH.  Update tests.