### PR TITLE
the mix of classic and pv2 notices hurts, a lot, when trying to handl…

### DIFF
--- a/webServer/routes/ceProjects.js
+++ b/webServer/routes/ceProjects.js
@@ -21,10 +21,9 @@ class CEProjects {
 		}
 	    }
 	}
-	console.log( "CEP find", host, org, hostProjId, "GOT", retVal );
 	if( retVal == config.EMPTY ) {
+	    console.log( "CEP find", host, org, hostProjId, "GOT", retVal );
 	    this.show(50);
-	    assert( false );  // XXX debugging
 	}
 	return retVal;
     }
@@ -43,7 +42,6 @@ class CEProjects {
 	for( const entry of this.cep ) {
 	    await this.add( authData, entry );
 	}
-	this.show(50);
     }
 
     // Called during server initialization,
@@ -112,6 +110,7 @@ class CEProjects {
 	return retVal
     }
 
+    // XXX does not properly show repositories, nor projectIds.  lists, oi?
     show( count ) {
 	console.log( "CEProjects Map contents" );
 	if( Object.keys( this.hp2cp ).length <= 0 ) { return ""; }

--- a/webServer/routes/gh/gh2/cardHandler.js
+++ b/webServer/routes/gh/gh2/cardHandler.js
@@ -173,7 +173,7 @@ async function deleteCard( authData, ghLinks, pd, cardId ) {
 // Can generate several notifications in one operation - so if creator is <bot>, ignore as pending.
 
 // NOTE this does not receive direct notifications, but is instead called from other handlers 
-async function handler( authData, ghLinks, ceProjects, pd, action, tag ) {
+async function handler( authData, ceProjects, ghLinks, pd, action, tag ) {
 
     pd.actor = pd.reqBody.sender.login;
     let card = pd.reqBody.projects_v2_item;

--- a/webServer/routes/gh/gh2/itemHandler.js
+++ b/webServer/routes/gh/gh2/itemHandler.js
@@ -25,7 +25,7 @@ const cardHandler = require( './cardHandler' );
 //            Implies: {open} newborn issue will not create linkage.. else the attached PEQ would be confusing
 
 
-async function handler( authData, ghLinks, ceProjects, pd, action, tag ) {
+async function handler( authData, ceProjects, ghLinks, pd, action, tag ) {
 
     console.log( authData.who, "itemHandler start", authData.job );
     
@@ -101,17 +101,17 @@ async function handler( authData, ghLinks, ceProjects, pd, action, tag ) {
 	    // Need to then process the content-specific notice for details.
 	    // Example:  { field_value: { field_node_id: 'PVTF_<*>', field_type: 'labels' }}
 	    // No need to rebuild the map on server startup, since notice comes every time.  Demote content_node job this notice hasn't arrived yet.
-	    console.log( "PV2ItemHandler", action );
+	    console.log( authData.who, "PV2ItemHandler", action );
 
 	    if( ghUtils.validField( reqBody, "changes" )) {
 		let fv = reqBody.changes.field_value;
 		if( ghUtils.validField( fv, "field_type" )) {
 		    
 		    if( fv.field_type == "single_select" ) {
-			await cardHandler.handler( authData, ghLinks, ceProjects, pd, 'moved', tag );
+			await cardHandler.handler( authData, ceProjects, ghLinks, pd, 'moved', tag );
 		    }
 		    else if( fv.field_type == "labels" ) {
-			console.log( "Item handler found edit:labels.. no action taken in favor of issue:labels" );
+			console.log( authData.who, "Item handler found edit:labels.. no action taken in favor of issue:labels" );
 		    }
 		}
 	    }
@@ -132,9 +132,9 @@ async function handler( authData, ghLinks, ceProjects, pd, action, tag ) {
 	break;
     case 'created':
 	// creating a card here.
-	// generated from situateIssue or adding issue to project in GH
+	// generated from cardIssue or adding issue to project in GH
 	{
-	    cardHandler.handler( authData, ghLinks, ceProjects, pd, action, tag ); 
+	    cardHandler.handler( authData, ceProjects, ghLinks, pd, action, tag ); 
 	}
 	break;
     case 'deleted':

--- a/webServer/routes/githubTestHandler.js
+++ b/webServer/routes/githubTestHandler.js
@@ -11,7 +11,7 @@ async function handler( ghLinks, ceJobs, ceProjects, ceNotification, reqBody, re
     }
     // use ONLY to verify test outcome in CE before performing dependent step.
     else if( reqBody.Request == "getLocs" ) {
-	console.log( "Test handler returning locs" );
+	// console.log( "Test handler returning locs" );
 	retVal = ghLinks.locs;
     }
     // use ONLY to verify test outcome in CE before performing dependent step.

--- a/webServer/tests/gh/gh2/gh2TestUtils.js
+++ b/webServer/tests/gh/gh2/gh2TestUtils.js
@@ -682,7 +682,8 @@ async function makeAllocCard( authData, ghLinks, ceProjId, rNodeId, pNodeId, col
     allocIssue.title = title;
     allocIssue.labels = [label];
 
-    let issDat = await ghV2.createIssue( authData, rNodeId, pNodeId, allocIssue );
+    // creating a peq issue.  do not card it, issue:label does the work
+    let issDat = await ghV2.createIssue( authData, rNodeId, -1, allocIssue );
     assert( issDat.length == 3 && issDat[0] != -1 && issDat[2] != -1 );
 
     await ghV2.moveCard( authData, pNodeId, issDat[2], statusId, colId );
@@ -752,7 +753,7 @@ async function makeProjectCard( authData, ghLinks, ceProjId, pNodeId, colId, iss
     return card;
 }
 
-// NOTE this creates an unsituated issue.  Call 'createProjectCard' to situate it.
+// NOTE this creates an uncarded issue.  Call 'createProjectCard' to situate it.
 async function makeIssue( authData, td, title, labels ) {
     let issue = await ghV2.createIssue( authData, td.GHRepoId, -1, {title: title, labels: labels} );
     issue.push( title );
@@ -760,7 +761,7 @@ async function makeIssue( authData, td, title, labels ) {
     return issue;
 }
 
-// NOTE this creates an unsituated issue.  Call 'createProjectCard' to situate it.
+// NOTE this creates an uncarded issue.  Call 'createProjectCard' to situate it.
 async function makeAllocIssue( authData, td, title, labels ) {
     let issue = await ghV2.createIssue( authData, td.GHRepoId, -1, {title: title, labels: labels, allocation: true} );
     issue.push( title );
@@ -768,7 +769,7 @@ async function makeAllocIssue( authData, td, title, labels ) {
     return issue;
 }
 
-// NOTE this creates an unsituated issue.  Call 'createProjectCard' to situate it.
+// NOTE this creates an uncarded issue.  Call 'createProjectCard' to situate it.
 async function blastIssue( authData, td, title, labels, assignees, specials ) {
     let wait  = typeof specials !== 'undefined' && specials.hasOwnProperty( "wait" )   ? specials.wait   : true;
 

--- a/webServer/tests/gh/gh2/testSetup.js
+++ b/webServer/tests/gh/gh2/testSetup.js
@@ -48,6 +48,7 @@ async function createPreferredCEProjects( authData, ghLinks, td ) {
 
     // softCont: dataSecurity, githubOps, unallocated
     await gh2tu.makeAllocCard( authData, ghLinks, td.ceProjectId, td.GHRepoId, td.masterPID, mastCol1.hostColumnId, td.dataSecTitle, "1,000,000" );
+    assert( false );
     await gh2tu.makeAllocCard( authData, ghLinks, td.ceProjectId, td.GHRepoId, td.masterPID, mastCol1.hostColumnId, td.githubOpsTitle, "1,500,000" );
     await gh2tu.makeAllocCard( authData, ghLinks, td.ceProjectId, td.GHRepoId, td.masterPID, mastCol1.hostColumnId, td.unallocTitle, "3,000,000" );
 

--- a/webServer/utils/gh/gh2/gh2DataUtils.js
+++ b/webServer/utils/gh/gh2/gh2DataUtils.js
@@ -164,6 +164,7 @@ async function populateCELinkage( authData, ghLinks, pd )
 
 
 // Only routes here are from issueHandler:label (peq only), or cardHandler:create (no need to be peq)
+// cardHandler:create passes in -1 for link
 async function processNewPEQ( authData, ghLinks, pd, issue, link, specials ) {
     let issDat = [issue.title];
 
@@ -227,7 +228,8 @@ async function processNewPEQ( authData, ghLinks, pd, issue, link, specials ) {
 	assert( link == -1 );
 
 	let card = await ghV2.getCard( authData, origCardId );
-	pd.columnId = card.columnId;
+	// No reason to do this, situated non-peq do not track col data
+	// pd.columnId = card.columnId;                     
 	colName = card.columnName;
 
 	console.log( "PNP: type 1", pd.columnId, colName );


### PR DESCRIPTION
…e both styles of project.  Current approach is

probably broken.  Get job summary, authorization, switching all need too much handling to pick the right path. Was hoping to revamp this after basic flow testing done, but not practicaly.  Will now work towards project management system
of GHC IFF rb.repository is in GHC ceProject, explicitly.   Herein, createIssue was additionally carding a newly created peq issue.
Trying to deal with createIssue in some forms which generate only a content notice, but will also generate PV2 notice if the issue is carded.
Realized that bot-sent notifications are not being picked up on due to authorization error.  darg..