### PR TITLE
linkage:unlinkProject was killing links for entire ceproj incorrectly

### DIFF
--- a/webServer/routes/githubRouter.js
+++ b/webServer/routes/githubRouter.js
@@ -385,6 +385,12 @@ function makePendingNotice( rb, action ) {
 
     let pn = {};
     if( action == "edited" ) {
+ 	// ghost creeps in sometimes, ignore it.  Seen during issue:close, card:move
+	if( rb.sender.login == config.GH_GHOST ) {
+	    console.log( "Boo!  GH ghost notification, do not create notice.", rb.projects_v2_item.project_node_id, rb.projects_v2_item.content_node_id );
+	    return {id: config.EMPTY, hpid: config.EMPTY, org: config.EMPTY, mod: config.EMPTY};
+	}
+
 	assert( typeof rb.changes !== 'undefined' && typeof rb.changes.field_value !== 'undefined' && typeof rb.changes.field_value.field_type !== 'undefined' );
 	assert( typeof rb.organization !== 'undefined' );
 	pn.mod  = rb.changes.field_value.field_type;

--- a/webServer/utils/gh/gh2/ghV2Utils.js
+++ b/webServer/utils/gh/gh2/ghV2Utils.js
@@ -346,7 +346,7 @@ async function getIssues( authData, repoNodeId ) {
 		issues.push( datum );
 	    }
 	})
-	.catch( e => issues = ghUtils.errorHandler( "getIssues", e, getIssues, authData, td )); 
+	.catch( e => issues = ghUtils.errorHandler( "getIssues", e, getIssues, authData, repoNodeId )); 
 
     return issues;
 }


### PR DESCRIPTION
move getIssues from gh2tu to ghV2, prepare to use it in linkage.initonerepo ghV2:getIssues error handler call incorrect
GH is issuing new ghost notices, ignore them.
First round of tests are all running again, time to break bad dependence on link/unlink project.