### PR TITLE
create Multi Proj for multithreading testing

### DIFF
--- a/webServer/routes/gh/gh2/labelHandler.js
+++ b/webServer/routes/gh/gh2/labelHandler.js
@@ -196,6 +196,7 @@ async function handler( authData, ceProjects, ghLinks, pd, action, tag ) {
 		    // XXX hmm.. if init error mismatching peq, this will fire.  not an issue during test construction (i.e. frequent mismatches), just production.
 		    console.log( authData.who, "WARNING.  Links exist on deleted label.  Mismatching peq during server init?", peq, links );  // need await somewhere for aws?
 		    // assert( links.length == 1 );
+		    return;
 		}
 
 		// PEQ labels are updated during ingest - they can be out of date.  Make sure issue is not already peq-labeled.

--- a/webServer/tests/gh/gh2/gh2TestUtils.js
+++ b/webServer/tests/gh/gh2/gh2TestUtils.js
@@ -1297,7 +1297,6 @@ async function checkSituatedIssue( authData, testLinks, td, loc, issDat, card, t
 		
 		let pacts    = allPacts.filter((pact) => pact.Subject[0] == peq.PEQId );
 		subTest   = tu.checkGE( pacts.length, 1,                         subTest, "PAct count" );
-		if( pacts.length != 1 ) { console.log( "uh oh", peq.PEQId ); }
 		
 		// This can get out of date quickly.  Only check this if early on, before lots of moving (which PEQ doesn't keep up with)
 		if( pacts.length <= 3 && loc.projSub.length > 1 ) {
@@ -1311,7 +1310,7 @@ async function checkSituatedIssue( authData, testLinks, td, loc, issDat, card, t
 		for( const pact of pacts ) {
 		    let hr  = await tu.hasRaw( authData, pact.PEQActionId );
 		    subTest = tu.checkEq( hr, true,                                subTest, "PAct Raw match" ); 
-		    subTest = tu.checkEq( pact.HostUserName, config.TEST_ACTOR,      subTest, "PAct user name" ); 
+		    subTest = tu.checkEq( pact.HostUserName, td.actor,             subTest, "PAct user name" ); 
 		    subTest = tu.checkEq( pact.Locked, "false",                    subTest, "PAct locked" );
 		    
 		    if( !muteIngested ) { subTest = tu.checkEq( pact.Ingested, "false", subTest, "PAct ingested" ); }

--- a/webServer/tests/gh/testMain.js
+++ b/webServer/tests/gh/testMain.js
@@ -80,11 +80,6 @@ async function runV2Tests( testStatus, flutterTest, authData, authDataX, authDat
     await utils.sleep( 5000 );
     testStatus = tu.mergeTests( testStatus, subTest );
 
-    subTest = await gh2TestCross.runTests( flutterTest, authData, authDataX, authDataM, testLinks, td, tdX, tdM );
-    console.log( "\n\nCross Repo test complete." );
-    //await utils.sleep( 5000 );
-    testStatus = tu.mergeTests( testStatus, subTest );
-
     subTest = await gh2TestBasicFlow.runTests( authData, testLinks, td );
     console.log( "\n\nFlow test complete." );
     await utils.sleep( 5000 );
@@ -100,7 +95,11 @@ async function runV2Tests( testStatus, flutterTest, authData, authDataX, authDat
     await utils.sleep( 5000 );
     testStatus = tu.mergeTests( testStatus, subTest );
 
-    
+    subTest = await gh2TestCross.runTests( flutterTest, authData, authDataX, authDataM, testLinks, td, tdX, tdM );
+    console.log( "\n\nCross Repo test complete." );
+    //await utils.sleep( 5000 );
+    testStatus = tu.mergeTests( testStatus, subTest );
+
     return testStatus;
 }
 

--- a/webServer/utils/gh/gh2/linkageUtils.js
+++ b/webServer/utils/gh/gh2/linkageUtils.js
@@ -37,9 +37,9 @@ async function buildHostLinks( authData, ghLinks, ceProject, baseLinks, locData 
 
     // Add organization's unclaimed to each hostRepo that holds PEQ, since aws:peq table will not record delete movements to UNCL
     let unclPID = await ghV2.findProjectByName( authData, org, "", config.UNCLAIMED ); 
-    if( unclPID != -1 ) { hostProjs.push( unclPID ); }
+    if( unclPID != -1 && !hostProjs.includes( unclPID ) ) { hostProjs.push( unclPID ); }
     
-    console.log( "HOST PROJs", ceProject.CEProjectId, hostProjs );
+    console.log( "HOST PROJs POST", ceProject.CEProjectId, hostProjs );
     
     // Note, for links being built below, the link is a complete ceServer:link that supplied info for the 1:1 mapping issue:card.
     //       it is not necessarily a complete picture of a host link (which ceServer does not need).
@@ -57,7 +57,7 @@ async function buildHostLinks( authData, ghLinks, ceProject, baseLinks, locData 
 	
 	// hostProjs may contain issues from other ceProjects.  Filter these out by requiring hostRepo to match one of the list in ceProjects
 	// initialization of the other ceProjects will pick up these filtered out links.
-	rLinks = rLinks.filter( (link) => hostRepoIds.includes( link.hostRepoId ) );
+	rLinks = rLinks.filter( (link) => hostRepoIds.includes( link.hostRepoId ));
 	
 	// console.log( authData.who, "Populate Linkage", pid );
 	rLinks.forEach( function (link) { ghLinks.addLinkage( authData, ceProject.CEProjectId, link, { populate: true } );


### PR DESCRIPTION
Update multithread test
ghV2:getLabels improve return when issue no longer exists settleWait for unclaimed cards in multithread, instead of guessing sleep time.  This is taking longer than expected. gh2tu:checkSituated check for td.actor, not config.TEST_ACTOR.. actor depends on test linkageUtils:initOne was pushing unclaimedPID twice ghV2:getHostLinkLoc fix association of repo to issue.  Was assuming 1 single call to GHLL needed only one hostRepo - but projects are views, this was a significant error. multiThread is working.
update testCross:getCardsHelp to filter for interleave All tests are passing!