### PR TITLE
Fix mishap in flutter integration tests.. if ariTester does not have …

### DIFF
--- a/ceFlutter/testCEFlutter.py
+++ b/ceFlutter/testCEFlutter.py
@@ -213,6 +213,11 @@ def runTests( test = "focus" ):
     resultsSum = ""
     tSum = ""
 
+    # Every test can start with ariTester having the exec role.  Several fail without it.
+    cmd = "npm run enableAri --prefix ../webServer"
+    npmRun = runCmd( cmd, [] )
+    logging.info( npmRun )
+    
     if( test == "projectMain" ):
 
         # XXX Ouch!! Cmon flutter.. integration tests need to be able to terminate

--- a/webServer/package.json
+++ b/webServer/package.json
@@ -9,6 +9,7 @@
         "testFlutter": "node ./tests/gh/testMain.js ceFlutter",
         "checkPeqs": "node ./tests/gh/checkPeqs.js",
         "sanityCheck": "node ./tests/sanityCheck.js",
+	"enableAri": "node -e 'import(\"./tests/enableAri.js\").then( m => m.runTests())'",
         "cleanFlutter": "node ./tests/gh/cleanLoad.js",
         "testSetup": "node ./tests/gh/testSetup.js",
         "testDelete": "node ./tests/gh/gh2/testDelete.js",

--- a/webServer/tests/enableAri.js
+++ b/webServer/tests/enableAri.js
@@ -1,0 +1,67 @@
+import assert from 'assert';
+
+import * as awsAuth   from '../auth/aws/awsAuth.js';
+import * as config    from '../config.js';
+
+import * as awsUtils  from '../utils/awsUtils.js';
+import authDataC      from '../auth/authData.js';
+
+async function setCEVTestRoles( authData, cevId ) {
+    // get CEV
+    let cev = await awsUtils.getCEV( authData, cevId );
+
+    // update roles for ari.. note this is a pure aws record
+    if( typeof cev.Roles === 'undefined' ) {
+	console.log( "Fail.  Roles not found" );
+	assert( false );
+    }
+    
+    console.log( "Current roles:" );
+    Object.entries( cev.Roles ).forEach( ([k,v]) => console.log( "   ", k, v ) );
+    let mod      = false;
+    let foundAri = false;
+    Object.entries( cev.Roles ).forEach( ([k,v]) => {
+	if( k == "eaeIqcqqdp" ) { // XXX
+	    foundAri = true;
+	    if( v != "Executive" ) {
+		v = "Executive";   // XXX
+		mod = true;
+	    }
+	}
+    });
+
+    if( !foundAri ) {
+	cev.Roles["eaeIqcqqdp"] = "Executive";
+	mod = true;
+    }
+
+    // put cev
+    if( mod ) {
+	console.log( "New roles:" );
+	Object.entries( cev.Roles ).forEach( ([k,v]) => console.log( "   ", k, v ) );
+	await awsUtils.updateCEVenture( authData, cev ); 
+    }
+}
+
+// NOTE: for flutter testing, only.
+async function runTests() {
+    console.log( "Make sure ariTester has exec role for testing" );
+
+    let authData     = new authDataC();
+    authData.who     = "<TEST: Flutter> ";
+    authData.api     = awsUtils.getAPIPath() + "/find";
+    authData.cog     = await awsAuth.getCogIDToken();
+
+    await setCEVTestRoles( authData, config.FLUTTER_TEST_CEVID );
+    await setCEVTestRoles( authData, config.FLUTTER_MULTI_TEST_CEVID );
+    await setCEVTestRoles( authData, config.FLUTTER_CROSS_TEST_CEVID );
+    await setCEVTestRoles( authData, config.FAIL_CROSS_TEST_CEVID );
+
+}
+
+
+export {setCEVTestRoles};
+export {runTests};
+
+// npm run enableAri
+//runTests();

--- a/webServer/tests/gh/gh2/gh2TestUtils.js
+++ b/webServer/tests/gh/gh2/gh2TestUtils.js
@@ -578,44 +578,6 @@ async function remProject( authData, pid ) {
     await utils.sleep( tu.MIN_DELAY );
 }
 
-// call from testMain
-async function setCEVTestRoles( authData, cevId ) {
-    // get CEV
-    let cev = await awsUtils.getCEV( authData, cevId );
-
-    // update roles for ari.. note this is a pure aws record
-    if( typeof cev.Roles === 'undefined' ) {
-	console.log( "Fail.  Roles not found" );
-	assert( false );
-    }
-    
-    console.log( "Current roles:" );
-    Object.entries( cev.Roles ).forEach( ([k,v]) => console.log( "   ", k, v ) );
-    let mod      = false;
-    let foundAri = false;
-    Object.entries( cev.Roles ).forEach( ([k,v]) => {
-	if( k == "eaeIqcqqdp" ) { // XXX
-	    foundAri = true;
-	    if( v != "Executive" ) {
-		v = "Executive";   // XXX
-		mod = true;
-	    }
-	}
-    });
-
-    if( !foundAri ) {
-	cev.Roles["eaeIqcqqdp"] = "Executive";
-	mod = true;
-    }
-
-    // put cev
-    if( mod ) {
-	console.log( "New roles:" );
-	Object.entries( cev.Roles ).forEach( ([k,v]) => console.log( "   ", k, v ) );
-	await awsUtils.updateCEVenture( authData, cev ); 
-    }
-}
-
 
 // do NOT move to ghV2 - this is used during testing only.  handlers are oblivious to this view-centric action.
 async function unlinkProject( authData, ceProjId, pid, rNodeId ) {
@@ -2128,8 +2090,6 @@ export {getQuad};
 export {createProjectWorkaround};
 export {createDefaultProject};
 export {remProject};
-
-export {setCEVTestRoles};
 
 export {cloneFromTemplate};   // XXX speculative.  useful?
 export {createCustomField};   // XXX speculative.  useful?

--- a/webServer/tests/gh/testMain.js
+++ b/webServer/tests/gh/testMain.js
@@ -20,6 +20,7 @@ import ceProjData     from '../../routes/ceProjects.js';
 import testData       from './testData.js';
 
 import testSaveDynamo from '../testSaveDynamo.js';
+import * as ari       from '../enableAri.js';
 
 // GH Classic
 import * as ghctu        from './ghc/ghcTestUtils.js';
@@ -65,11 +66,11 @@ async function runV2Tests( testStatus, flutterTest, authData, authDataX, authDat
     gh2tu.unlinkProject( authData, td.ceProjectId, wakeyPID, td.ghRepoId );
 
     // Set roles properly for Ari.. Ari can get bashed during flutter integration tests
-    await gh2tu.setCEVTestRoles( authData, td.cepDetails.ceVentureId );
-    await gh2tu.setCEVTestRoles( authData, tdX.cepDetails.ceVentureId );
-    await gh2tu.setCEVTestRoles( authData, tdM.cepDetails.ceVentureId );
-    await gh2tu.setCEVTestRoles( authData, tdF.cepDetails.ceVentureId );
-    
+    await ari.setCEVTestRoles( authData, td.cepDetails.ceVentureId );
+    await ari.setCEVTestRoles( authData, tdX.cepDetails.ceVentureId );
+    await ari.setCEVTestRoles( authData, tdM.cepDetails.ceVentureId );
+    await ari.setCEVTestRoles( authData, tdF.cepDetails.ceVentureId );
+
     // TESTS
 
     let subTest = "";

--- a/webServer/tests/testSaveDynamo.js
+++ b/webServer/tests/testSaveDynamo.js
@@ -56,7 +56,6 @@ async function runTests( flutterTest ) {
     let success = false;
 
     // turn this on when not testing in parts
-
     success = execAWS_CLI( "CEPEQs", flutterTest );
     testStatus = tu.checkEq( success, true, testStatus, "save PEQ Table" );
 


### PR DESCRIPTION
…exec privilege, equity plan can't be updated, and onboarding can't run without an equity plan.

Now, ariTester roles are set before every test - flutter or server.